### PR TITLE
Support for ubuntu 18.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,15 +8,16 @@ Overview
 
 To create Debian packages of CKAN, install Vagrant and Ansible and run::
 
-    ./ckan-package -v dev-v2.6 -i beta1
+    ./ckan-package -v dev-v2.8 -i 1
 
 If you omit the parameters you will be prompted for them.
 
 After Vagrant and Ansible have done their thing (it will take a while), you
-should end up with two deb files on the working folder::
+should end up with three deb files on the working folder::
 
-    python-ckan_dev-v2.6-trusty1_amd64.deb
-    python-ckan_dev-v2.6-xenial1_amd64.deb
+    python-ckan_dev-v2.8-trusty1_amd64.deb
+    python-ckan_dev-v2.8-xenial1_amd64.deb
+    python-ckan_dev-v2.8-bionic1_amd64.deb
 
 Keep reading for more options and to learn how it works.
 
@@ -31,6 +32,7 @@ Each machine is running one of the supported distributions that we target, curre
 
 * Ubuntu 14.04 64bit (trusty)
 * Ubuntu 16.04 64bit (xenial)
+* Ubuntu 18.04 64bit (bionic)
 
 We use `Ansible <http://ansible.com>`_ to provision the Vagrant machines, which
 results in the creation of the package. Ansible is configured via
@@ -83,7 +85,7 @@ full list of options and parameters::
 
 Most of the times you will want to run something like the following::
 
-    ./ckan-package -v ckan-2.6.0 -i 1
+    ./ckan-package -v dev-v2.8 -i 1
 
 Where:
 
@@ -93,7 +95,7 @@ Where:
 This will build two packages successively, one for trusty and one for xenial. If you
 only want to target one distribution, you can pass the ``-t`` parameter::
 
-    ./ckan-package --version release-v2.4.2 --iteration 1 --target trusty
+    ./ckan-package --version dev-v2.8 --iteration 1 --target bionic
 
 The first time that you run the build commands Vagrant will
 need to download the OS images from the central repository, this might take a while.

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Where:
  * -v (version) relates to the CKAN  branch or tag to build, eg master, dev-v2.6, release-v2.5.3
  * -i (iteration) e.g. `beta1` for a beta or for a proper release use a number e.g. `1`
 
-This will build two packages successively, one for trusty and one for xenial. If you
+This will build three packages successively, one for trusty, one for xenial and one for bionic. If you
 only want to target one distribution, you can pass the ``-t`` parameter::
 
     ./ckan-package --version dev-v2.8 --iteration 1 --target bionic

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "xenial" do |xenial|
     xenial.vm.box = "ubuntu/xenial64"
   end
+  
+  config.vm.define "bionic" do |bionic|
+    xenial.vm.box = "ubuntu/bionic64"
+  end
 
   config.ssh.forward_agent = true
   config.vm.provider "virtualbox" do |v|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
   
   config.vm.define "bionic" do |bionic|
-    xenial.vm.box = "ubuntu/bionic64"
+    bionic.vm.box = "ubuntu/bionic64"
   end
 
   config.ssh.forward_agent = true

--- a/bionic/etc/apache2/sites-available/ckan_default.conf
+++ b/bionic/etc/apache2/sites-available/ckan_default.conf
@@ -1,0 +1,23 @@
+WSGISocketPrefix /var/run/wsgi
+<VirtualHost 0.0.0.0:8080>
+
+    ServerName default.ckanhosted.com
+    ServerAlias www.default.ckanhosted.com
+    WSGIScriptAlias / /etc/ckan/default/apache.wsgi
+
+    # pass authorization info on (needed for rest api)
+    WSGIPassAuthorization On
+
+    # Deploy as a daemon (avoids conflicts between CKAN instances)
+    WSGIDaemonProcess ckan_default display-name=ckan_default processes=2 threads=15
+
+    WSGIProcessGroup ckan_default
+
+    ErrorLog /var/log/apache2/ckan_default.error.log
+    CustomLog /var/log/apache2/ckan_default.custom.log combined
+
+    <Directory />
+    Require all granted
+    </Directory>
+
+</VirtualHost>

--- a/ckan-package
+++ b/ckan-package
@@ -44,7 +44,7 @@ def run(target=None):
             
     if target is None or target == 'bionic':
             status_bionic = re.search('bionic\s*(\w+)', out).group(1)
-            print 'Machine "bionic" is ' + status_bionicl
+            print 'Machine "bionic" is ' + status_bionic
 
     if (status_trusty and status_trusty != 'running') or \
             (status_xenial and status_xenial != 'running') or \

--- a/ckan-package
+++ b/ckan-package
@@ -29,6 +29,7 @@ def run(target=None):
 
     status_trusty = None
     status_xenial = None
+    status_bionic = None
 
     print 'Checking Vagrant machines status...'
     out = subprocess.check_output(['vagrant', 'status'])
@@ -40,9 +41,14 @@ def run(target=None):
     if target is None or target == 'xenial':
             status_xenial = re.search('xenial\s*(\w+)', out).group(1)
             print 'Machine "xenial" is ' + status_xenial
+            
+    if target is None or target == 'bionic':
+            status_bionic = re.search('bionic\s*(\w+)', out).group(1)
+            print 'Machine "bionic" is ' + status_bionicl
 
     if (status_trusty and status_trusty != 'running') or \
-            (status_xenial and status_xenial != 'running'):
+            (status_xenial and status_xenial != 'running') or \
+                (status_bionic and status_bionic != 'running'):
         print 'Starting up machine(s)'
         command = ['vagrant', 'up', '--provision']
     else:
@@ -72,7 +78,7 @@ If not provided you will be propmt for it''')
                         help='''Whether to add the DataPusher to the package,
 defaults to true''')
     parser.add_argument('-t', '--target',
-                        help='''The distribution to target (trusty or xenial).
+                        help='''The distribution to target (trusty or xenial or bionic).
 If omitted, both are built''')
     parser.add_argument('-a', '--ansible-verbose',
                         default='vv',
@@ -93,7 +99,7 @@ If omitted, both are built''')
     iteration = _check_arg(args, 'iteration', 'Iteration')
     datapusher = args.datapusher
     target = args.target
-    if target and target not in ('trusty', 'xenial'):
+    if target and target not in ('trusty', 'xenial', 'bionic'):
         print 'Wrong target: ' + target
         sys.exit(1)
     ansible_verbose = args.ansible_verbose

--- a/common/tmp/after_web.j2
+++ b/common/tmp/after_web.j2
@@ -81,7 +81,7 @@ done
 
     {% endif %}
 
-    {% if ansible_distribution_version == "14.04" or ansible_distribution_version == "16.04"%}
+    {% if ansible_distribution_version == "14.04" or ansible_distribution_version == "16.04" or ansible_distribution_version == "18.04" %}
 
         if [ ! -f /etc/apache2/sites-available/datapusher ];
         then

--- a/package.yml
+++ b/package.yml
@@ -14,6 +14,7 @@
   tasks:
     - name: make sure packages are installed
       apt:
+        force_apt_get: yes
         name:
           - 'git-core'
           - 'python-dev'

--- a/package.yml
+++ b/package.yml
@@ -31,6 +31,10 @@
     - name: stop apache before installing nginx (xenial)
       service: name=apache2 state=stopped
       when: ansible_distribution_version == "16.04"
+      
+    - name: stop apache before installing nginx (bionic)
+      service: name=apache2 state=stopped
+      when: ansible_distribution_version == "18.04"
 
     - name: make sure nginx is installed
       action: apt pkg=nginx state=present update_cache=yes
@@ -42,6 +46,10 @@
     - name: install fpm (xenial)
       action: command gem install -v 1.11.0 fpm -- creates=/usr/local/bin/fpm
       when: ansible_distribution_version == "16.04"
+      
+    - name: install fpm (bionic)
+      action: command gem install -v 1.11.0 fpm -- creates=/usr/local/bin/fpm
+      when: ansible_distribution_version == "18.04"
 
     - name: delete old directories
       action: file path={{ item }} state=absent

--- a/package.yml
+++ b/package.yml
@@ -31,11 +31,7 @@
 
     - name: stop apache before installing nginx (xenial)
       service: name=apache2 state=stopped
-      when: ansible_distribution_version == "16.04"
-      
-    - name: stop apache before installing nginx (bionic)
-      service: name=apache2 state=stopped
-      when: ansible_distribution_version == "18.04"
+      when: (ansible_distribution_version == "16.04") or (ansible_distribution_version == "18.04")
 
     - name: make sure nginx is installed
       action: apt pkg=nginx state=present update_cache=yes


### PR DESCRIPTION
Added support for ubuntu 18.04 in Vagrantfile, build scripts and ansible.

Tested it on an Ubuntu 18.04 virtual machine with the dev-v2.8 package install instructions and it did work without issues. 

I can make the .deb file available for any testing

I'm more familiar with bitbucket (and CVS from a long time ago :-) ) so please let me know if I'm not following protocols...