### PR TITLE
Update for CKAN 2.11

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     focal.vm.box = "ubuntu/jammy64"
   end
 
+  config.vm.define "noble" do |focal|
+    focal.vm.box = "ubuntu/noble64"
+  end
+
   config.ssh.forward_agent = true
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024

--- a/ckan-package
+++ b/ckan-package
@@ -35,6 +35,7 @@ def run(target=None):
 
     status_jammy = None
     status_focal = None
+    status_noble = None
 
     print("Checking Vagrant machines status...")
     out = subprocess.check_output(["vagrant", "status"]).decode("utf8")
@@ -45,9 +46,13 @@ def run(target=None):
     if target is None or target == "jammy":
         status_jammy = get_status(out, "jammy")
         print('Machine "jammy" is ' + status_jammy)
+    if target is None or target == "noble":
+        status_noble = get_status(out, "noble")
+        print('Machine "noble" is ' + status_noble)
 
     if (status_jammy and status_jammy != "running") or (
-        status_focal and status_focal != "running"
+        status_focal and status_focal != "running") or (
+        status_noble and status_noble != "running"
     ):
         print("Starting up machine(s)")
         command = ["vagrant", "up", "--provision"]

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,12 @@
+Build debian packages:
+2.10 - focal
+2.10 - jammy
+2.11 - jammy
+2.11 - noble
+
+20.04 = Focal
+22.04 = Jammy
+24.04 = Noble 
+
+1. Update Vagrantfile
+2. Update ckan-package


### PR DESCRIPTION
For the CKAN 2.11 release the target will be the following:

| CKAN version | Ubuntu version | Python version |
| --- | --- | --- |
| 2.10 | 20.04 (focal) | Python 3 |
| 2.10 | 22.04 (jammy) | Python 3 |
| 2.11 | 22.04 (jammy) | Python 3 |
| 2.11 | 24.04 (noble) | Python 3 |
